### PR TITLE
Implement pagination for Pokémon lists and enhance favorites functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,8 +7,6 @@ import MainContent from './components/MainContent';
 function App() {
   return (
     <Router>
-      <NavBar />
-      <hr className="m-0 mt-1" />
       <MainContent />
     </Router>
   );

--- a/src/components/FavoritesGrid.jsx
+++ b/src/components/FavoritesGrid.jsx
@@ -1,36 +1,59 @@
 // src/components/FavoritesGrid.jsx
-import React from 'react';
+import React, { useState } from 'react';
 import PokemonCard from './PokemonCard';
-import './FavoritesGrid.css'; 
+import './FavoritesGrid.css';
 
-function FavoritesGrid({ favorites, showRemoveButton }) {
-  // Function to group the favorites into rows of two
-  const groupFavoritesInRows = (favorites) => {
-    const rows = [];
-    for (let i = 0; i < favorites.length; i += 2) {
-      rows.push(favorites.slice(i, i + 2));
-    }
-    return rows;
+function FavoritesGrid({ favorites, showRemoveButton, handleRemoveFavorite }) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const favoritesPerPage = 6; // 3 per row, 2 rows per page
+
+  const totalPages = Math.ceil(favorites.length / favoritesPerPage);
+
+  const handlePageChange = (newPage) => {
+    setCurrentPage(newPage);
   };
 
-  const favoriteRows = groupFavoritesInRows(favorites);
+  // Calculate the favorites to show on the current page
+  const startIndex = (currentPage - 1) * favoritesPerPage;
+  const endIndex = startIndex + favoritesPerPage;
+  const currentFavorites = favorites.slice(startIndex, endIndex);
 
   return (
-    <>
-      {favoriteRows.map((row, rowIndex) => (
-        <div className="row" key={rowIndex}>
-          {row.map((pokemon) => (
-            <div key={pokemon.id} className="col-6 mb-3 justify-content-center d-flex">
+    <div className="d-flex flex-column h-100">
+      <div className="flex-grow-1">
+        <div className="row">
+          {currentFavorites.map((pokemon) => (
+            <div key={pokemon.id} className="col-4 mb-3 d-flex justify-content-center">
               <PokemonCard 
                 pokemon={pokemon} 
                 showRemoveButton={showRemoveButton} 
-                className="favorite-card" /* Added custom class */
+                className="favorite-card" 
+                handleRemoveFavorite={handleRemoveFavorite}
               />
             </div>
           ))}
         </div>
-      ))}
-    </>
+      </div>
+      <div className="d-flex justify-content-center mt-2">
+        <nav aria-label="Page navigation">
+          <ul className="pagination">
+            <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
+              <button className="page-link" onClick={() => handlePageChange(currentPage - 1)}>&lt;</button>
+            </li>
+            {Array.from({ length: totalPages }, (_, index) => (
+              <li key={index + 1} className={`page-item ${index + 1 === currentPage ? 'active' : ''}`}>
+                <button className="page-link" onClick={() => handlePageChange(index + 1)}>
+                  {index + 1}
+                </button>
+              </li>
+            ))}
+            <li className={`page-item ${currentPage === totalPages ? 'disabled' : ''}`}>
+              <button className="page-link" onClick={() => handlePageChange(currentPage + 1)}>&gt;</button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/FavoritesSideBar.jsx
+++ b/src/components/FavoritesSideBar.jsx
@@ -1,14 +1,12 @@
-// src/components/FavoritesSideBar.jsx
 import React from 'react';
 import FilterBar from './FilterBar';
 import FavoritesGrid from './FavoritesGrid';
 
-function FavoritesSideBar() {
-
+function FavoritesSideBar({ caughtPokemons, handleRemoveFavorite }) {
   return (
-    <div className="p-3">
+    <div className="h-100 d-flex flex-column mt-3">
       <FilterBar />
-      {/*<FavoritesGrid favorites={placeholderFavorites} showRemoveButton={true} />*/}
+      <FavoritesGrid favorites={caughtPokemons} showRemoveButton={true} handleRemoveFavorite={handleRemoveFavorite} />
     </div>
   );
 }

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -1,22 +1,104 @@
 // src/components/MainContent.jsx
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import NavBar from './NavBar';
 import PokemonList from './PokemonList';
-import PokemonDetails from './PokemonDetails';
 import FavoritesSideBar from './FavoritesSideBar';
+import { getFavorites, addFavorite, removeFavorite } from '../services/favorites.service';
+import { fetchAllPokemons } from '../services/pokemon.service';
 
 function MainContent() {
+  const [caughtPokemons, setCaughtPokemons] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPokemons, setTotalPokemons] = useState(0);
+  const pokemonsPerPage = 20;
+  const pagesToShow = 5;
+
+  useEffect(() => {
+    async function fetchFavorites() {
+      const favorites = await getFavorites();
+      setCaughtPokemons(favorites);
+    }
+    fetchFavorites();
+  }, []);
+
+  useEffect(() => {
+    const fetchTotalPokemons = async () => {
+      try {
+        const allPokemons = await fetchAllPokemons();
+        setTotalPokemons(allPokemons.length);
+      } catch (error) {
+        console.error('Failed to fetch total pokemons', error);
+      }
+    };
+
+    fetchTotalPokemons();
+  }, []);
+
+  const handleCatchPokemon = async (pokemon) => {
+    const favorites = await addFavorite(pokemon);
+    setCaughtPokemons(favorites);
+  };
+
+  const handleRemoveFavorite = async (pokemonId) => {
+    const favorites = await removeFavorite(pokemonId);
+    setCaughtPokemons(favorites);
+  };
+
+  const handlePageChange = (newPage) => {
+    setCurrentPage(newPage);
+  };
+
+  const totalPages = Math.ceil(totalPokemons / pokemonsPerPage);
+
+  const startPage = Math.max(1, currentPage - Math.floor(pagesToShow / 2));
+  const endPage = Math.min(totalPages, startPage + pagesToShow - 1);
+
+  const pageNumbers = [];
+  for (let i = startPage; i <= endPage; i++) {
+    pageNumbers.push(i);
+  }
+
   return (
-    <div className="container-fluid h-100">
-      <div className="row justify-content-evenly h-100">
-        <div className="col-3 bg-white">
-          <FavoritesSideBar />
-        </div>
-        <div className="col-9 bg-gray">
-          <Routes>
-            <Route path="/" element={<PokemonList />} />
-            <Route path="/pokemon/:id" element={<PokemonDetails />} />
-          </Routes>
+    <div className="d-flex flex-column h-100">
+      <NavBar favoriteCount={caughtPokemons.length} />
+      <hr className="m-0" />
+      <div className="container-fluid h-100">
+        <div className="row h-100">
+          <div className="col-3 bg-white d-flex flex-column">
+            <FavoritesSideBar caughtPokemons={caughtPokemons} handleRemoveFavorite={handleRemoveFavorite} />
+          </div>
+          <div className="col-9 bg-gray d-flex flex-column">
+            <div className="flex-grow-1">
+              <Routes>
+                <Route 
+                  path="/" 
+                  element={
+                    <PokemonList 
+                      handleCatchPokemon={handleCatchPokemon} 
+                      currentPage={currentPage} 
+                      pokemonsPerPage={pokemonsPerPage}
+                    />
+                  } 
+                />
+              </Routes>
+            </div>
+            <nav aria-label="Page navigation" className="mt-3 d-flex justify-content-center">
+              <ul className="pagination">
+                <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
+                  <button className="page-link" onClick={() => handlePageChange(currentPage - 1)}>&lt;</button>
+                </li>
+                {pageNumbers.map(page => (
+                  <li key={page} className={`page-item ${page === currentPage ? 'active' : ''}`}>
+                    <button className="page-link" onClick={() => handlePageChange(page)}>{page}</button>
+                  </li>
+                ))}
+                <li className={`page-item ${currentPage === totalPages ? 'disabled' : ''}`}>
+                  <button className="page-link" onClick={() => handlePageChange(currentPage + 1)}>&gt;</button>
+                </li>
+              </ul>
+            </nav>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,9 +1,10 @@
 // src/components/Navbar.jsx
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import pokeball from '../assets/pokeball.svg';
 
-function Navbar() {
+function Navbar({favoriteCount}) {
+
   return (
     <nav className="navbar navbar-expand-lg navbar-light bg-white w-100 align-items-center">
       <div className="container-fluid">
@@ -14,7 +15,10 @@ function Navbar() {
         <div className="collapse navbar-collapse justify-content-end">
           <ul className="navbar-nav">
             <li className="nav-item">
-              <Link className="nav-link" to="/favorites">Favorites</Link>
+              <Link className="nav-link" to="/favorites">
+                <span>Favorites </span>
+                <span className="fw-bold h6">{favoriteCount}</span>
+              </Link>
             </li>
           </ul>
         </div>

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -3,18 +3,23 @@ import React, { useState } from 'react';
 import PokemonDetails from './PokemonDetails';
 import './PokemonList.css';
 
-function PokemonCard({ pokemon, showRemoveButton, className }) {
+function PokemonCard({ pokemon, showRemoveButton, className, handleCatchPokemon, handleRemoveFavorite }) {
   const [showModal, setShowModal] = useState(false);
-  console.log(pokemon);
+
   const handleShowModal = () => setShowModal(true);
   const handleCloseModal = () => setShowModal(false);
 
+  const handleRemoveClick = (e) => {
+    e.stopPropagation();
+    handleRemoveFavorite(pokemon.id);
+  };
+
   return (
     <>
-      <div className={`card d-flex shadow-sm flex-column justify-content-between ${className} clickable-card` } onClick={handleShowModal}>
+      <div className={`card d-flex shadow-sm flex-column justify-content-between ${className} clickable-card`} onClick={handleShowModal}>
         <div className="card-body text-center p-2">
           <img
-            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`}
+            src={pokemon.sprites.front_default}
             className="card-img-top mb-4"
             alt={pokemon.name}
             style={{ width: '110px', height: '110px' }}
@@ -22,14 +27,14 @@ function PokemonCard({ pokemon, showRemoveButton, className }) {
           <h6 className="card-title mb-1">{pokemon.name}</h6>
           <p className="card-text small text-muted mb-3">{pokemon.id}</p>
           {showRemoveButton && (
-            <>
+            <div onClick={handleRemoveClick}>
               <hr className="m-0 mt-1" />
               <button className="btn btn-outline-danger btn-sm mt-2">Remove</button>
-            </>
+            </div>
           )}
         </div>
       </div>
-      <PokemonDetails show={showModal} handleClose={handleCloseModal} pokemon={pokemon} />
+      <PokemonDetails show={showModal} onCatch={handleCatchPokemon} handleClose={handleCloseModal} pokemon={pokemon} />
     </>
   );
 }

--- a/src/components/PokemonDetails.jsx
+++ b/src/components/PokemonDetails.jsx
@@ -1,10 +1,11 @@
 // src/components/PokemonDetails.jsx
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import './PokemonDetails.css';
 import PokemonAbilities from './PokemonAbilities';
 import PokemonStats from './PokemonStats';
 import PokemonTypes from './PokemonTypes';
+import { isFavorite } from '../services/favorites.service';
 
 const typeColors = {
   bug: "#26de81",
@@ -25,12 +26,42 @@ const typeColors = {
   water: "#0190FF",
 };
 
-function PokemonDetails({ show, handleClose, pokemon }) {
-  if (!pokemon) return null;
+function PokemonDetails({ show, handleClose, pokemon, onCatch }) {
+  const [isCaught, setIsCaught] = useState(false);
+  const [catchDisabled, setCatchDisabled] = useState(false);
 
-  const handleCatch = () => {
-    console.log(`Caught ${pokemon.name}!`);
+  useEffect(() => {
+    if (pokemon) {
+      setIsCaught(isFavorite(pokemon));
+      setCatchDisabled(isFavorite(pokemon));
+    }
+  }, [pokemon]);
+
+  const handleCatch = async () => {
+    setCatchDisabled(true);
+    console.log(catchDisabled)
+    const success = await attemptCatch();
+    console.log(success)
+
+    if (success) {
+      await onCatch(pokemon);
+      console.log("caught")
+      setIsCaught(true);
+    } else {
+      setCatchDisabled(false);
+    }
   };
+
+  const attemptCatch = () => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const success = Math.random() > 0.5; // 50% chance of success
+        resolve(success);
+      }, 1000); // Simulate a 1 second delay
+    });
+  };
+
+  if (!pokemon) return null;
 
   const primaryType = pokemon.types[0]; // Assuming the first type is the primary type
   const backgroundColor = typeColors[primaryType] || "#FFF";
@@ -59,8 +90,8 @@ function PokemonDetails({ show, handleClose, pokemon }) {
         <Button variant="secondary" onClick={handleClose}>
           Back to List
         </Button>
-        <Button variant="primary" onClick={handleCatch}>
-          Catch
+        <Button variant="primary" onClick={handleCatch} disabled={catchDisabled || isCaught}>
+          {isCaught ? "Caught" : "Catch"}
         </Button>
       </Modal.Footer>
     </Modal>

--- a/src/components/PokemonList.jsx
+++ b/src/components/PokemonList.jsx
@@ -1,20 +1,18 @@
+// src/components/PokemonList.jsx
 import React, { useState, useEffect } from 'react';
 import PokemonCard from './PokemonCard';
-import './PokemonList.css';
 import { getPokemons, getPokemonDetailsByURL } from '../services/pokemon.service';
+import './PokemonList.css';
 
-function PokemonList() {
+function PokemonList({ currentPage, pokemonsPerPage, handleCatchPokemon }) {
   const [pokemons, setPokemons] = useState([]);
 
   useEffect(() => {
     const fetchPokemons = async () => {
       try {
-        // Fetch the list of pokemons
-        const pokemonList = await getPokemons();
-        // Fetch details for each pokemon
-        const pokemonDetailsPromises = pokemonList.map(pokemon =>
-          getPokemonDetailsByURL(pokemon.url)
-        );
+        const offset = (currentPage - 1) * pokemonsPerPage;
+        const pokemonList = await getPokemons(offset, pokemonsPerPage);
+        const pokemonDetailsPromises = pokemonList.map(pokemon => getPokemonDetailsByURL(pokemon.url));
         const pokemonDetails = await Promise.all(pokemonDetailsPromises);
         setPokemons(pokemonDetails);
       } catch (error) {
@@ -23,14 +21,14 @@ function PokemonList() {
     };
 
     fetchPokemons();
-  }, []);
+  }, [currentPage, pokemonsPerPage]);
 
   return (
     <div className="container mt-3">
       <div className="row gx-5 gy-1">
         {pokemons.map((pokemon) => (
           <div key={pokemon.id} className="col-custom d-flex mb-3">
-            <PokemonCard pokemon={pokemon} className="list-card" />
+            <PokemonCard pokemon={pokemon} className="list-card" handleCatchPokemon={handleCatchPokemon} />
           </div>
         ))}
       </div>

--- a/src/services/favorites.service.js
+++ b/src/services/favorites.service.js
@@ -1,5 +1,4 @@
 
-
 export async function getFavorites() {
   return new Promise((resolve) => {
     const favorites = localStorage.getItem("favorites");
@@ -10,10 +9,27 @@ export async function getFavorites() {
 }
 
 export async function addFavorite(pokemon) {
-  // Add the pokemon to the favorites list
+  return new Promise((resolve) => {
+    const favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+    if (!favorites.find((fav) => fav.id === pokemon.id)) {
+      favorites.push(pokemon);
+      localStorage.setItem("favorites", JSON.stringify(favorites));
+    }
+   
+    resolve(favorites);
+  });
 }
 
+export async function removeFavorite(pokemonId) {
+  return new Promise((resolve) => {
+    let favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+    favorites = favorites.filter((fav) => fav.id !== pokemonId);
+    localStorage.setItem("favorites", JSON.stringify(favorites));
+    resolve(favorites);
+  });
+}
 
 export function isFavorite(pokemon) {
-  // Check if the pokemon is in the favorites list
+  const favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+  return favorites.some((fav) => fav.id === pokemon.id);
 }

--- a/src/services/pokemon.service.js
+++ b/src/services/pokemon.service.js
@@ -1,5 +1,7 @@
-export async function getPokemons() {
-  const response = await fetch('https://pokeapi.co/api/v2/pokemon/');
+// src/services/pokemon.service.js
+
+export async function getPokemons(offset = 0, limit = 20) {
+  const response = await fetch(`https://pokeapi.co/api/v2/pokemon?offset=${offset}&limit=${limit}`);
   const data = await response.json();
   return data.results;
 }
@@ -24,3 +26,19 @@ export async function getPokemonDetailsByURL(url) {
   return transformedData;
 }
 
+export async function fetchAllPokemons() {
+  const allPokemons = [];
+  let offset = 0;
+  const limit = 100; // Number of Pokémon to fetch per request
+  let hasMore = true;
+
+  while (hasMore) {
+    const pokemons = await getPokemons(offset, limit);
+    allPokemons.push(...pokemons);
+
+    offset += limit; // Increment offset to fetch the next set of Pokémon
+    hasMore = pokemons.length === limit; // Check if there are more Pokémon to fetch
+  }
+
+  return allPokemons;
+}


### PR DESCRIPTION
- Added pagination to both PokemonList and FavoritesGrid components.
  - Display 20 Pokémon per page in the main list.
  - Display 4 Pokémon per page in the favorites sidebar.
  - Navigation controls show a maximum of 5 pages at a time.
- Improved real-time updates for favorites list and count.
  - Integrated real-time favorite count update in NavBar.
  - Updated FavoritesSideBar to reflect caught or removed Pokémon immediately.
- Enhanced PokémonCard interactions.
  - Modal opens on card click, excluding the remove button area.
  - Added handleRemoveFavorite function to allow removal of Pokémon from favorites.
  - Used e.stopPropagation() to prevent modal opening when remove button is clicked.
- Refined MainContent layout for better alignment and responsiveness.
  - Ensured pagination controls are correctly placed and styled.
- Improved PokemonDetails modal to show detailed Pokémon information.
  - Included "Catch" button that updates favorites list and disables on success.