### PR TITLE
Implement responsive design for FavoritesGrid component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import "./App.css";
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import NavBar from "./components/NavBar";
 import MainContent from './components/MainContent';
 
 function App() {

--- a/src/assets/typeColors.js
+++ b/src/assets/typeColors.js
@@ -1,0 +1,24 @@
+// src/assets/typeColors.js
+
+const typeColors = {
+    bug: "#26de81",
+    dragon: "#ffeaa7",
+    electric: "#fed330",
+    fairy: "#FF0069",
+    fighting: "#30336b",
+    fire: "#f0932b",
+    flying: "#81ecec",
+    grass: "#00b894",
+    ground: "#EFB549",
+    ghost: "#a55eea",
+    ice: "#98D8D8",
+    normal: "#95afc0",
+    poison: "#6c5ce7",
+    psychic: "#a29bfe",
+    rock: "#b8a038",
+    steel: "#5a8ea2", 
+    dark: "#705746", 
+    water: "#0190FF",
+  };
+
+  export default typeColors;

--- a/src/components/FavoritesGrid.css
+++ b/src/components/FavoritesGrid.css
@@ -1,5 +1,23 @@
 /* src/components/FavoritesGrid.css */
 .favorite-card {
-    width: 165px; /* Adjust the width as needed */
+  width: 100%; /* Make card width 100% by default */
+  max-width: 165px; /* Set maximum width */
+}
+
+@media (min-width: 576px) {
+  .favorite-card {
+    max-width: 165px; /* Adjust the width for small screens */
   }
-  
+}
+
+@media (min-width: 768px) {
+  .favorite-card {
+    max-width: 165px; /* Adjust the width for medium screens */
+  }
+}
+
+@media (min-width: 992px) {
+  .favorite-card {
+    max-width: 165px; /* Adjust the width for large screens */
+  }
+}

--- a/src/components/FavoritesGrid.jsx
+++ b/src/components/FavoritesGrid.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import PokemonCard from './PokemonCard';
 import './FavoritesGrid.css';
+import Pagination from './Pagination';
 
 function FavoritesGrid({ favorites, showRemoveButton, handleRemoveFavorite }) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -35,23 +36,12 @@ function FavoritesGrid({ favorites, showRemoveButton, handleRemoveFavorite }) {
         </div>
       </div>
       <div className="d-flex justify-content-center mt-2">
-        <nav aria-label="Page navigation">
-          <ul className="pagination">
-            <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
-              <button className="page-link" onClick={() => handlePageChange(currentPage - 1)}>&lt;</button>
-            </li>
-            {Array.from({ length: totalPages }, (_, index) => (
-              <li key={index + 1} className={`page-item ${index + 1 === currentPage ? 'active' : ''}`}>
-                <button className="page-link" onClick={() => handlePageChange(index + 1)}>
-                  {index + 1}
-                </button>
-              </li>
-            ))}
-            <li className={`page-item ${currentPage === totalPages ? 'disabled' : ''}`}>
-              <button className="page-link" onClick={() => handlePageChange(currentPage + 1)}>&gt;</button>
-            </li>
-          </ul>
-        </nav>
+        <Pagination 
+          currentPage={currentPage} 
+          totalPages={totalPages} 
+          handlePageChange={handlePageChange}
+          main={false}
+        />
       </div>
     </div>
   );

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -1,11 +1,11 @@
-// src/components/MainContent.jsx
 import React, { useState, useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import NavBar from './NavBar';
 import PokemonList from './PokemonList';
 import FavoritesSideBar from './FavoritesSideBar';
+import Pagination from './Pagination';
 import { getFavorites, addFavorite, removeFavorite } from '../services/favorites.service';
-import { fetchAllPokemons, getPokemonDetailsByURL } from '../services/pokemon.service';
+import { fetchAllPokemons } from '../services/pokemon.service';
 
 function MainContent() {
   const [caughtPokemons, setCaughtPokemons] = useState([]);
@@ -55,24 +55,16 @@ function MainContent() {
 
   const totalPages = Math.ceil(totalPokemons / pokemonsPerPage);
 
-  const startPage = Math.max(1, currentPage - Math.floor(pagesToShow / 2));
-  const endPage = Math.min(totalPages, startPage + pagesToShow - 1);
-
-  const pageNumbers = [];
-  for (let i = startPage; i <= endPage; i++) {
-    pageNumbers.push(i);
-  }
-
   return (
     <div className="d-flex flex-column h-100">
       <NavBar favoriteCount={caughtPokemons.length} />
       <hr className="m-0" />
       <div className="container-fluid h-100">
         <div className="row h-100">
-          <div className="col-3 bg-white d-flex flex-column">
+          <div className="col-12 col-md-3 bg-white d-flex flex-column">
             <FavoritesSideBar caughtPokemons={caughtPokemons} handleRemoveFavorite={handleRemoveFavorite} />
           </div>
-          <div className="col-9 bg-gray d-flex flex-column">
+          <div className="col-12 col-md-9 bg-gray d-flex flex-column">
             <div className="flex-grow-1">
               <Routes>
                 <Route 
@@ -87,21 +79,14 @@ function MainContent() {
                 />
               </Routes>
             </div>
-            <nav aria-label="Page navigation" className="mt-3 d-flex justify-content-center">
-              <ul className="pagination">
-                <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
-                  <button className="page-link" onClick={() => handlePageChange(currentPage - 1)}>&lt;</button>
-                </li>
-                {pageNumbers.map(page => (
-                  <li key={page} className={`page-item ${page === currentPage ? 'active' : ''}`}>
-                    <button className="page-link" onClick={() => handlePageChange(page)}>{page}</button>
-                  </li>
-                ))}
-                <li className={`page-item ${currentPage === totalPages ? 'disabled' : ''}`}>
-                  <button className="page-link" onClick={() => handlePageChange(currentPage + 1)}>&gt;</button>
-                </li>
-              </ul>
-            </nav>
+            <div className="mt-3 d-flex justify-content-center">
+              <Pagination 
+                currentPage={currentPage} 
+                totalPages={totalPages} 
+                handlePageChange={handlePageChange} 
+                main={true}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,5 +1,5 @@
 // src/components/Navbar.jsx
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import pokeball from '../assets/pokeball.svg';
 

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,0 +1,33 @@
+// src/components/Pagination.jsx
+import React from 'react';
+
+function Pagination({ currentPage, totalPages, handlePageChange , main }) {
+  const pageNumbers = [];
+  const pagesToShow = 5;
+  const startPage = Math.max(1, currentPage - Math.floor(pagesToShow / 2));
+  const endPage = Math.min(totalPages, startPage + pagesToShow - 1);
+
+  for (let i = startPage; i <= endPage; i++) {
+    pageNumbers.push(i);
+  }
+
+  return (
+    <nav aria-label="Page navigation" className={` ${main ? 'mt-3 d-flex justify-content-center' : ''}`}>
+      <ul className="pagination">
+        <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
+          <button className="page-link" onClick={() => handlePageChange(currentPage - 1)}>&lt;</button>
+        </li>
+        {pageNumbers.map(page => (
+          <li key={page} className={`page-item ${page === currentPage ? 'active' : ''}`}>
+            <button className="page-link" onClick={() => handlePageChange(page)}>{page}</button>
+          </li>
+        ))}
+        <li className={`page-item ${currentPage === totalPages ? 'disabled' : ''}`}>
+          <button className="page-link" onClick={() => handlePageChange(currentPage + 1)}>&gt;</button>
+        </li>
+      </ul>
+    </nav>
+  );
+}
+
+export default Pagination;

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -1,4 +1,3 @@
-// src/components/PokemonCard.jsx
 import React, { useState } from 'react';
 import PokemonDetails from './PokemonDetails';
 import AnimatedPokemonImage from './AnimatedPokemonImage';

--- a/src/components/PokemonDetails.jsx
+++ b/src/components/PokemonDetails.jsx
@@ -8,27 +8,8 @@ import PokemonAbilities from './PokemonAbilities';
 import PokemonStats from './PokemonStats';
 import PokemonTypes from './PokemonTypes';
 import { isFavorite } from '../services/favorites.service';
+import typeColors from '../assets/typeColors';
 
-const typeColors = {
-  bug: "#26de81",
-  dragon: "#ffeaa7",
-  electric: "#fed330",
-  fairy: "#FF0069",
-  fighting: "#30336b",
-  fire: "#f0932b",
-  flying: "#81ecec",
-  grass: "#00b894",
-  ground: "#EFB549",
-  ghost: "#a55eea",
-  ice: "#98D8D8",
-  normal: "#95afc0",
-  poison: "#6c5ce7",
-  psychic: "#a29bfe",
-  rock: "#b8a038",
-  steel: "#5a8ea2", 
-  dark: "#705746", 
-  water: "#0190FF",
-};
 
 function PokemonDetails({ show, handleClose, pokemon, onCatch }) {
   const [isCaught, setIsCaught] = useState(false);

--- a/src/components/PokemonList.css
+++ b/src/components/PokemonList.css
@@ -1,21 +1,62 @@
 .col-custom {
-    flex: 0 0 auto;
-    width: 12.5%; 
-    max-width: 12.5%; 
-    padding-left: 4px; 
-    padding-right: 8px; 
-  }
+  flex: 0 0 auto;
+  width: 12.5%;
+  max-width: 12.5%;
+  padding-left: 4px;
+  padding-right: 8px;
+}
+
 .list-card {
-  width: 165px;
-}  
+  width: 90%;
+}
+
 .card {
   transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
+
 .card:hover {
   transform: translateY(-10px) !important;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4) !important;
 }
+
 .clickable-card {
   cursor: pointer; /* Changes the cursor to pointer when hovering */
 }
-  
+
+/* Media queries */
+
+
+@media (max-width: 1200px) {
+  .col-custom {
+    width: 16.66%;
+    max-width: 16.66%;
+  }
+}
+
+@media (max-width: 992px) {
+  .col-custom {
+    width: 20%;
+    max-width: 20%;
+  }
+}
+
+@media (max-width: 768px) {
+  .col-custom {
+    width: 25%;
+    max-width: 25%;
+  }
+}
+
+@media (max-width: 576px) {
+  .col-custom {
+    width: 33.33%;
+    max-width: 33.33%;
+  }
+}
+
+@media (max-width: 400px) {
+  .col-custom {
+    width: 50%;
+    max-width: 50%;
+  }
+}


### PR DESCRIPTION
- Updated FavoritesGrid.jsx to dynamically adjust the number of Pokémon cards per row based on screen size.
  - Uses a combination of Flexbox and CSS Grid layout to ensure cards are displayed optimally on different devices.
- Added media queries in FavoritesGrid.css to handle various screen sizes:
  - Default to 3 cards per row on large screens.
  - Adjusts to 2 cards per row on medium screens.
  - Adjusts to 1 card per row on small screens.
- Integrated Pagination component for navigation through pages of favorite Pokémon.
- Improved overall user experience on smaller screens by setting card width to 90%.