### PR TITLE
feat: Implement initial Pokémon batch fetch with session storage caching

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -8,7 +8,7 @@ import { getFavorites, addFavorite, removeFavorite } from '../../services/favori
 import PokemonContext from '../../contexts/PokemonContext';
 
 function MainContent() {
-  const { caughtPokemons, allPokemons, totalPokemons, setCaughtPokemons } = useContext(PokemonContext);
+  const { caughtPokemons, totalPokemons, setCaughtPokemons } = useContext(PokemonContext);
   const [currentPage, setCurrentPage] = useState(1);
   const pokemonsPerPage = 24;
 
@@ -60,7 +60,6 @@ function MainContent() {
           <div className="col-12 col-md-9 bg-gray d-flex flex-column">
             <div className="flex-grow-1">
               <PokemonList
-                pokemons={allPokemons} 
                 handleCatchPokemon={handleCatchPokemon} 
                 currentPage={currentPage} 
                 pokemonsPerPage={pokemonsPerPage}

--- a/src/components/Pokemon/PokemonList.jsx
+++ b/src/components/Pokemon/PokemonList.jsx
@@ -1,11 +1,13 @@
 // src/components/PokemonList/PokemonList.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import PokemonCard from './PokemonCard';
+import PokemonContext from '../../contexts/PokemonContext';
 import './PokemonList.css';
 
-function PokemonList({pokemons, currentPage, pokemonsPerPage, handleCatchPokemon }) {
+function PokemonList({currentPage, pokemonsPerPage, handleCatchPokemon }) {
+  const { allPokemons, firstBatch } = useContext(PokemonContext);
   // State to hold the list of Pokemons
-  const [currentPokemons, setCurrentPokemons] = useState([]);
+  const [currentPokemons, setCurrentPokemons] = useState(firstBatch);
   
   useEffect(() => {
     // Function to fetch Pokemons based on current page and items per page
@@ -15,7 +17,7 @@ function PokemonList({pokemons, currentPage, pokemonsPerPage, handleCatchPokemon
         const startIndex = (currentPage - 1) * pokemonsPerPage;
         const endIndex = startIndex + pokemonsPerPage;
          // Set the current Pokémon slice to state.
-        const pokemonList = pokemons.slice(startIndex, endIndex);
+        const pokemonList = allPokemons.slice(startIndex, endIndex);
         setCurrentPokemons(pokemonList);
       } catch (error) {
         console.error('Failed to fetch pokemons', error);
@@ -23,7 +25,7 @@ function PokemonList({pokemons, currentPage, pokemonsPerPage, handleCatchPokemon
     };
 
     fetchPokemons();
-  }, [currentPage, pokemonsPerPage]);
+  }, [currentPage, pokemonsPerPage, allPokemons]);
 
   return (
     <div className="container-fluid mt-3">

--- a/src/contexts/PokemonContext.jsx
+++ b/src/contexts/PokemonContext.jsx
@@ -38,6 +38,12 @@ export const PokemonProvider = ({ children }) => {
         };
        
         fetchPokemons(); // Execute the fetch operation.
+        
+          // Cleanup function to clear session storage when the component unmounts.
+          return () => {
+            sessionStorage.removeItem('allPokemons');
+            sessionStorage.removeItem('totalPokemons');
+        };
     }, []);
 
     // Context provider that supplies caught and all Pokémon data to child components.

--- a/src/contexts/PokemonContext.jsx
+++ b/src/contexts/PokemonContext.jsx
@@ -1,6 +1,6 @@
 // src/contexts/PokemonContext.js
 import React, { createContext, useState, useEffect } from 'react';
-import { fetchAllPokemons } from '../services/pokemon.service';
+import { fetchAllPokemons, getPokemonDetailsByURL, getPokemons } from '../services/pokemon.service';
 
 // Create a context for sharing Pokémon data across the React component tree.
 const PokemonContext = createContext();
@@ -8,6 +8,12 @@ const PokemonContext = createContext();
 export const PokemonProvider = ({ children }) => {
     // State for managing caught Pokémon.
     const [caughtPokemons, setCaughtPokemons] = useState([]);
+
+    // State for storing the first batch of Pokémon (first 24).
+    const [firstBatch, setFirstBatch] = useState(() => {
+        const stored = sessionStorage.getItem('firstBatch');
+        return stored ? JSON.parse(stored) : [];
+    });
 
     // State for storing all Pokémon. Initial state is loaded from session storage to avoid unnecessary API calls.
     const [allPokemons, setAllPokemons] = useState(() => {
@@ -22,8 +28,31 @@ export const PokemonProvider = ({ children }) => {
     
     // Effect that fetches all Pokémon data only if it's not already stored in session storage.
     useEffect(() => {
+        const fetchInitialPokemons = async () => {
+            // Check if the first batch of Pokémon is stored in session storage
+            const firstBatchStored = sessionStorage.getItem('firstBatch');
+            if (!firstBatchStored || JSON.parse(firstBatchStored).length === 0) {
+                // If not, fetch the initial batch of Pokémon
+                try {
+                    const [initialPokemons] = await getPokemons(0, 24);
+                     // Fetch detailed information for each Pokémon in the initial batch
+                    const detailedInitialPokemons = await Promise.all(
+                        initialPokemons.map(pokemon => getPokemonDetailsByURL(pokemon.url))
+                    );
+                    // Update state with the fetched data
+                    setFirstBatch(detailedInitialPokemons);
+                    setAllPokemons(detailedInitialPokemons);
+                    // Store the fetched data in session storage for future use
+                    sessionStorage.setItem('firstBatch', JSON.stringify(detailedInitialPokemons));
+                } catch (error) {
+                    console.error('Failed to fetch initial Pokemons', error);
+                }
+            } 
+        };
+
         const fetchPokemons = async () => {
-            if (!sessionStorage.getItem('allPokemons')) { // Check if the data is already cached.
+            const allPokemonsStored = sessionStorage.getItem('allPokemons');
+            if (!allPokemonsStored || JSON.parse(allPokemonsStored).length === 0) { // Check if the data is already cached.
                 try {
                     const [fetchedPokemons, pokemonCount] = await fetchAllPokemons();
                     setAllPokemons(fetchedPokemons); // Update state with fetched data.
@@ -36,20 +65,17 @@ export const PokemonProvider = ({ children }) => {
                 }
             }
         };
-       
-        fetchPokemons(); // Execute the fetch operation.
-        
-          // Cleanup function to clear session storage when the component unmounts.
-          return () => {
-            sessionStorage.removeItem('allPokemons');
-            sessionStorage.removeItem('totalPokemons');
-        };
+
+        // Execute the fetch operations.
+        fetchInitialPokemons();
+        fetchPokemons(); 
+
     }, []);
 
     // Context provider that supplies caught and all Pokémon data to child components.
     return (
-        <PokemonContext.Provider value={{ caughtPokemons, allPokemons, totalPokemons, setCaughtPokemons }}>
-            {children} // Render child components that now have access to Pokémon context.
+        <PokemonContext.Provider value={{ caughtPokemons, firstBatch, allPokemons, totalPokemons, setCaughtPokemons }}>
+            {children} {/* Render child components that now have access to Pokémon context. */}
         </PokemonContext.Provider>
     );
 };

--- a/src/services/pokemon.service.js
+++ b/src/services/pokemon.service.js
@@ -51,13 +51,13 @@ export async function fetchAllPokemons() {
 
   while (hasMore) {
     // Fetch a batch of Pokémon and update total count.
-    const [pokemons, pokemonCount] = await fetchPokemonsBatch(offset, limit);
+    const [pokemons, pokemonCount] = await getPokemons(offset, limit);
     if (totalPokemonsCount === 0) {
       totalPokemonsCount = pokemonCount;
     }
 
     // Fetch detailed data for each Pokémon in the batch.
-    const detailsPromises = pokemons.map(pokemon => fetchPokemonDetails(pokemon.url));
+    const detailsPromises = pokemons.map(pokemon => getPokemonDetailsByURL(pokemon.url));
     const detailedPokemons = await Promise.all(detailsPromises);
     allPokemons.push(...detailedPokemons);
 


### PR DESCRIPTION
 - Added logic to fetch the initial batch of Pokémon (first 24) if not present in session storage.
 - Included detailed Pokémon data fetching for the initial batch.
 - Updated state with the fetched Pokémon data.
 - Stored the fetched initial batch in session storage to avoid redundant API calls on page refresh.
 - Added comments for better code clarity and maintenance.

This ensures efficient data loading and improves user experience by minimizing unnecessary network requests.